### PR TITLE
[#2] Initial pgmoneta_ext skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.bundle/
+_site/
+build/
+vendor/
+.vscode/
+.cache
+*.uncrustify
+.DS_Store

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 pgmoneta_ext was created by the following authors:
 
 Jesper Pedersen <jesper.pedersen@comcast.net>
+Chao Gu <chadraven369@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.14)
+
+set(VERSION_MAJOR "0")
+set(VERSION_MINOR "1")
+set(VERSION_PATCH "0")
+set(VERSION_STRING ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+
+#
+# Avoid source tree pollution
+#
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
+If(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR "In-source builds are not permitted. Make a separate folder for building:\nmkdir build; cd build; cmake ..\nBefore that, remove the files already created:\nrm -rf CMakeCache.txt CMakeFiles")
+endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+
+project(pgmoneta_ext VERSION ${VERSION_STRING} LANGUAGES  C)
+
+set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH})
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME
+  "${CMAKE_PROJECT_NAME}-${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+set(CPACK_SOURCE_IGNORE_FILES
+  "/build/;/.git/;/.github/;/*.patch;/.bundle/;/_site/;/vendor/;~$;${CPACK_SOURCE_IGNORE_FILES}")
+include(CPack)
+
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+message(STATUS "pgmoneta_ext ${VERSION_STRING}")
+
+include(CheckCCompilerFlag)
+include(CheckCSourceCompiles)
+include(FindPackageHandleStandardArgs)
+include(GNUInstallDirs)
+
+if (NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: Debug Release" FORCE)
+endif ()
+
+message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
+
+set(SUPPORTED_COMPILERS "GNU" "Clang" "AppleClang")
+
+# Check for a supported compiler
+if (NOT CMAKE_C_COMPILER_ID IN_LIST SUPPORTED_COMPILERS)
+   message(FATAL_ERROR "Unsupported compiler ${CMAKE_C_COMPILER_ID}. Supported compilers are: ${SUPPORTED_COMPILERS}")
+endif ()
+
+CHECK_C_COMPILER_FLAG("-std=c17" COMPILER_SUPPORTS_C17)
+if(NOT COMPILER_SUPPORTS_C17)
+  message(FATAL_ERROR "The compiler ${CMAKE_C_COMPILER} has no C17 support. Please use a different C compiler.")
+endif()
+
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/")
+
+add_subdirectory(src)
+add_subdirectory(sql)

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -1,0 +1,22 @@
+# retrieve the shared directory of the PostgreSQL installation
+execute_process(COMMAND pg_config --sharedir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE SHARE_DIR)
+
+# handle the result
+if (SHARE_DIR)
+  set(SHARE_DIR "${SHARE_DIR}/extension")
+  message(STATUS "Extension directory: ${SHARE_DIR}")
+else (SHARE_DIR)
+  message(FATAL_ERROR "pg_config --sharedir failed")
+endif (SHARE_DIR)
+
+# Installing SQL Files
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+        DESTINATION "${SHARE_DIR}" 
+        FILES_MATCHING PATTERN "*.sql")
+
+# Installing Control Files
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+        DESTINATION "${SHARE_DIR}" 
+        FILES_MATCHING PATTERN "*.control")

--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -1,0 +1,3 @@
+CREATE FUNCTION pgmoneta_version_ext() RETURNS text 
+AS 'MODULE_PATHNAME' 
+LANGUAGE C STRICT;

--- a/sql/pgmoneta_ext.control
+++ b/sql/pgmoneta_ext.control
@@ -1,0 +1,5 @@
+# pgmoneta_ext extension
+comment = 'pgmoneta extension for delta backup'
+default_version = '0.1.0'
+module_pathname = '$libdir/pgmoneta_ext'
+relocatable = true

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,179 @@
+#
+# Add files for pgmoneta_ext
+#
+FILE(GLOB SOURCE_FILES "pgmoneta_ext/*.c")
+FILE(GLOB HEADER_FILES "include/*.h")
+
+set(SOURCES ${SOURCE_FILES} ${HEADER_FILES})
+
+#
+# Retrieving PostgreSQL configuration paths
+#
+execute_process(COMMAND pg_config --includedir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE EXT_INCLUDE_DIR)
+
+if (EXT_INCLUDE_DIR)
+  message(STATUS "Include directory: ${EXT_INCLUDE_DIR}")
+else (EXT_INCLUDE_DIR)
+  message(FATAL_ERROR "pg_config --includedir failed")
+endif (EXT_INCLUDE_DIR)
+
+execute_process(COMMAND pg_config --includedir-server
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE EXT_INCLUDE_SERVER_DIR)
+
+if (EXT_INCLUDE_SERVER_DIR)
+  message(STATUS "Include directory: ${EXT_INCLUDE_SERVER_DIR}")
+else (EXT_INCLUDE_SERVER_DIR)
+  message(FATAL_ERROR "pg_config --includedir-server failed")
+endif (EXT_INCLUDE_SERVER_DIR)
+
+execute_process(COMMAND pg_config --pkglibdir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE EXT_INSTALL_DIR)
+
+if (EXT_INSTALL_DIR)
+  message(STATUS "Library directory: ${EXT_INSTALL_DIR}")
+else (EXT_INSTALL_DIR)
+  message(FATAL_ERROR "pg_config --pkglibdir failed")
+endif (EXT_INSTALL_DIR)
+
+execute_process(COMMAND pg_config --libdir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE EXT_LIB_DIR)
+
+if (EXT_LIB_DIR)
+  message(STATUS "Library directory: ${EXT_LIB_DIR}")
+else (EXT_LIB_DIR)
+  message(FATAL_ERROR "pg_config --libdir failed")
+endif (EXT_LIB_DIR)
+
+#
+# OS
+#
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+
+  add_compile_options(-DHAVE_LINUX)
+  add_compile_options(-D_POSIX_C_SOURCE=200809L)
+
+  #
+  # Include directories
+  #
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${EXT_INCLUDE_DIR}
+    ${EXT_INCLUDE_SERVER_DIR}
+  )
+
+  #
+  # Library directories
+  #
+  link_libraries(
+    ${EXT_LIB_DIR}/libpq.so
+  )
+
+else()
+
+  add_compile_options(-D_XOPEN_SOURCE=700)
+  add_compile_options(-D_BSD_SOURCE)
+  add_compile_options(-D_DEFAULT_SOURCE)
+  add_compile_options(-D__BSD_VISIBLE)
+
+  #
+  # Include directories
+  #
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${EXT_INCLUDE_DIR}
+    ${EXT_INCLUDE_SERVER_DIR}
+  )
+
+  #
+  # Library directories
+  #
+  link_libraries(
+    ${EXT_LIB_DIR}/libpq.so
+  )
+endif()
+
+#
+# Compile options
+#
+add_compile_options(-g)
+add_compile_options(-Wall)
+add_compile_options(-std=c17)
+add_compile_options(-D__USE_ISOC11)
+add_compile_options(-D_GNU_SOURCE)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  add_compile_options(-Wstrict-prototypes)
+endif()
+
+if (CMAKE_BUILD_TYPE MATCHES Debug)
+  add_compile_options(-O0)
+  add_compile_options(-DDEBUG)
+
+  check_c_compiler_flag(-fno-omit-frame-pointer HAS_NO_OMIT_FRAME_POINTER)
+  if (HAS_NO_OMIT_FRAME_POINTER)
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fno-omit-frame-pointer")
+  endif()
+endif()
+
+if (CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+  add_compile_options(-O2)
+  add_compile_options(-DNDEBUG)
+endif (CMAKE_BUILD_TYPE MATCHES Release OR CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+
+check_c_compiler_flag(-Wformat HAS_FORMAT)
+if (HAS_FORMAT)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat")
+endif()
+
+check_c_compiler_flag(-Wformat-security HAS_FORMAT_SECURITY)
+if (HAS_FORMAT_SECURITY)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-security")
+endif()
+
+check_c_compiler_flag(-fstack-protector-strong HAS_STACKPROTECTOR_STRONG)
+if (HAS_STACKPROTECTOR_STRONG)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-strong")
+else()
+  check_c_compiler_flag(-fstack-protector HAS_STACKPROTECTOR)
+  if (HAS_STACKPROTECTOR)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector")
+  endif()
+endif()
+
+check_c_compiler_flag(-rdynamic HAS_DYNAMIC)
+if (HAS_DYNAMIC)
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
+endif()
+
+check_c_compiler_flag(-fPIC HAS_PIC)
+if (HAS_PIC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+endif()
+
+check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)
+if (HAS_RELRO)
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
+endif()
+
+check_c_compiler_flag(-Wl,-z,now HAS_NOW)
+if (HAS_NOW)
+  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
+endif()
+
+#
+# Build pgmoneta_ext
+#
+add_library(pgmoneta_ext SHARED ${SOURCES})
+set_target_properties(pgmoneta_ext PROPERTIES LINKER_LANGUAGE C VERSION ${VERSION_STRING}
+                                     SOVERSION ${VERSION_MAJOR} PREFIX "")
+target_link_libraries(pgmoneta_ext PUBLIC)
+
+install(TARGETS pgmoneta_ext DESTINATION ${EXT_INSTALL_DIR}/)

--- a/src/include/pgmoneta_ext.h
+++ b/src/include/pgmoneta_ext.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PGMONETA_EXT_H
+#define PGMONETA_EXT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define VERSION "0.1.0"
+
+#define PGMONETA_EXT_HOMEPAGE "https://github.com/pgmoneta/pgmoneta_ext"
+#define PGMONETA_EXT_ISSUES "https://github.com/pgmoneta/pgmoneta_ext/issues"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/pgmoneta_ext/lib.c
+++ b/src/pgmoneta_ext/lib.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The pgmoneta community
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or other
+ * materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/* pgmoneta */
+#include <pgmoneta_ext.h>
+
+/* PostgreSQL */
+#include "postgres.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(pgmoneta_version_ext);
+
+Datum
+pgmoneta_version_ext(PG_FUNCTION_ARGS)
+{
+   Datum version;
+   char v[1024];
+
+   memset(&v, 0, sizeof(v));
+   snprintf(&v[0], sizeof(v), "%s", VERSION);
+
+   version = CStringGetTextDatum(v);
+
+   PG_RETURN_DATUM(version);
+}


### PR DESCRIPTION
- Set up the structure of `pgmoneta_ext`.
- Implement the initial function that returns the version number.

The screenshot below displays the test result, which did not return the expected version 1.0.0. I am unsure where the problem lies.
<img width="486" alt="Screenshot 2024-05-17 at 11 16 52 AM" src="https://github.com/pgmoneta/pgmoneta_ext/assets/113565433/ba04e3af-a71a-4c69-8d3c-e60f894a3572">