### PR TITLE
[#5] SQL: CHECKPOINT

### DIFF
--- a/cmake/FindPsqlDevel.cmake
+++ b/cmake/FindPsqlDevel.cmake
@@ -2,18 +2,40 @@
 # postgresql-server-devel Support
 #
 
+find_program(PG_CONFIG pg_config)
+
+if (NOT PG_CONFIG)
+    message(FATAL_ERROR "pg_config executable not found. Ensure PostgreSQL is installed and pg_config is in your PATH.")
+endif()
+
+# Use pg_config to get the include and library directories
+execute_process(COMMAND ${PG_CONFIG} --includedir
+                OUTPUT_VARIABLE PSQLDEVEL_INCLUDE_DIR
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process(COMMAND ${PG_CONFIG} --libdir
+                OUTPUT_VARIABLE PSQLDEVEL_LIBRARY_DIR
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 find_path(PSQLDEVEL_INCLUDE_DIR
   NAMES libpq-fe.h
-  PATH_SUFFIXES postgresql
+  PATHS ${PSQLDEVEL_INCLUDE_DIR}
 )
 
 find_library(PSQLDEVEL_LIBRARY
   NAMES pq
+  PATHS ${PSQLDEVEL_LIBRARY_DIR}
 )
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PsqlDevel DEFAULT_MSG
                                   PSQLDEVEL_INCLUDE_DIR PSQLDEVEL_LIBRARY)
+
+if (PSQLDEVEL_INCLUDE_DIR AND PSQLDEVEL_LIBRARY)
+  set(PSQLDEVEL_FOUND TRUE)
+else()
+  set(PSQLDEVEL_FOUND FALSE)
+endif()
 
 if (PSQLDEVEL_FOUND)
   set(PSQLDEVEL_INCLUDE_DIRS ${PSQLDEVEL_INCLUDE_DIR})

--- a/doc/manual/user-03-functions.md
+++ b/doc/manual/user-03-functions.md
@@ -4,11 +4,12 @@
 
 ## Security
 
-After you create the extension `pgmoneta_ext` using the `postgres` role, you can test all functions as shown below. Some functions may require superuser privileges (For the column `Superuser`, the value is `true`), so if you log in with a role without superuser privileges, the function will return `false`. If you have superuser privileges, it will work as desired.
+After you create the extension `pgmoneta_ext` using the `postgres` role, you can test all functions as shown below. Some functions may require specific privileges (For the column `Privilege`), so if you log in with a role without the specific privileges, the function will return `false`. If you have the specific privileges, it will work as desired.
 
 ## Extension functions
 
-| Function                    | Superuser | Description                                            |
+| Function                    | Privilege                    | Description                                            |
 |-----------------------------|-----------|--------------------------------------------------------|
-| `pgmoneta_ext_version()`    |   false   | Return the version number of `pgmoneta_ext` as a Datum.|
-| `pgmoneta_ext_switch_wal()` |   true    | A function for switching to a new WAL file.            |
+| `pgmoneta_ext_version()`    |   Default                      | Return the version number of `pgmoneta_ext` as a Datum.|
+| `pgmoneta_ext_switch_wal()` | SUPERUSER                   | A function for switching to a new WAL file.            |
+| `pgmoneta_ext_checkpoint()` | SUPERUSER <br>pg_checkpoint | A function which forces a checkpoint. <br>This function can only be executed by a `SUPERUSER` in PostgreSQL 13/14, but can also be executed by `pg_checkpoint` in PostgreSQL 15+. <br>You can use the SQL command `GRANT pg_checkpoint TO repl;` to assign the role in PostgreSQL 15+.|

--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -8,3 +8,10 @@ CREATE FUNCTION pgmoneta_ext_switch_wal(OUT success bool,
 RETURNS record 
 AS 'MODULE_PATHNAME' 
 LANGUAGE C STRICT;
+
+CREATE FUNCTION pgmoneta_ext_checkpoint(OUT success bool,
+                                        OUT value text
+) 
+RETURNS record 
+AS 'MODULE_PATHNAME' 
+LANGUAGE C STRICT;

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -39,14 +39,24 @@ extern "C" {
 #include "fmgr.h"
 
 /* system */
+#include <stdbool.h>
 
 /**
  * Check if the role has superuser privileges.
  * @param roleid The current role's ID
- * @return 0 upon success, otherwise 1
+ * @return The result
  */
-int
-pgmoneta_ext_check_privilege(Oid roleid);
+bool
+pgmoneta_ext_check_superuser(Oid roleid);
+
+/**
+ * Check if the role has specific role.
+ * @param roleid The current role's ID
+ * @param rolename Specific role name
+ * @return The result
+ */
+bool
+pgmoneta_ext_check_role(Oid roleid, const char* rolename);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Create a wrapper function for the `CHECKPOINT` functionality:

- Define the function pgmoneta_ext_checkpoint in the SQL file.
- Implement the C code in lib.c.

Test result:
<img width="659" alt="Screenshot 2024-05-27 at 6 34 37 PM" src="https://github.com/pgmoneta/pgmoneta_ext/assets/113565433/79da6455-e6af-4872-b85f-fb15e59fc67b">
