### PR TITLE
[#10] pgmoneta_ext_check_privilege

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -41,6 +41,10 @@ extern "C" {
 /* system */
 #include <stdbool.h>
 
+#define PRIVILEDGE_DEFAULT            1 << 0  // 001
+#define PRIVILEDGE_PG_CHECKPOINT      1 << 1  // 010
+#define PRIVILEDGE_SUPERUSER          1 << 2  // 100
+
 /**
  * Check if the role has superuser privileges.
  * @param roleid The current role's ID
@@ -57,6 +61,14 @@ pgmoneta_ext_check_superuser(Oid roleid);
  */
 bool
 pgmoneta_ext_check_role(Oid roleid, const char* rolename);
+
+/**
+ * Get a bit mask of the privileges of the role accessing.
+ * @param roleid The current role's ID
+ * @return The result
+ */
+int
+pgmoneta_ext_check_privilege(Oid roleid);
 
 #ifdef __cplusplus
 }

--- a/src/pgmoneta_ext/utils.c
+++ b/src/pgmoneta_ext/utils.c
@@ -108,3 +108,27 @@ pgmoneta_ext_check_role(Oid roleid, const char* rolename)
 
    return is_success;
 }
+
+int
+pgmoneta_ext_check_privilege(Oid roleid)
+{
+   int privileges = 0;
+
+   if (pgmoneta_ext_check_superuser(roleid))
+   {
+      privileges |= PRIVILEDGE_SUPERUSER;
+   }
+
+#if PG_VERSION_NUM >= 150000
+   bool is_pg_checkpoint = pgmoneta_ext_check_role(roleid, "pg_checkpoint");
+
+   if (is_pg_checkpoint)
+   {
+      privileges |= PRIVILEDGE_PG_CHECKPOINT;
+   }
+#endif
+
+   privileges |= PRIVILEDGE_DEFAULT;
+
+   return privileges;
+}


### PR DESCRIPTION
Add a new function `pgmoneta_ext_check_privilege` to check the role's privilege and return the bit mask.

- `PRIV_DEFAULT`                    0001
- `PRIV_PG_CHECKPOINT`     0011
- `PRIV_SUPERUSER`               1111