### PR TITLE
[#18] Get the specific database OID by using the database name

### DIFF
--- a/doc/manual/user-02-functions.md
+++ b/doc/manual/user-02-functions.md
@@ -8,8 +8,10 @@ After you create the extension `pgmoneta_ext` using the `postgres` role, you can
 
 ## Extension functions
 
-| Function                    | Privilege                    | Description                                            |
-|-----------------------------|-----------|--------------------------------------------------------|
-| `pgmoneta_ext_version()`    |   Default                      | Return the version number of `pgmoneta_ext` as a Datum.|
-| `pgmoneta_ext_switch_wal()` | SUPERUSER                   | A function for switching to a new WAL file.            |
-| `pgmoneta_ext_checkpoint()` | SUPERUSER <br>pg_checkpoint | A function which forces a checkpoint. <br>This function can only be executed by a `SUPERUSER` in PostgreSQL 13/14, but can also be executed by `pg_checkpoint` in PostgreSQL 15+. <br>You can use the SQL command `GRANT pg_checkpoint TO repl;` to assign the role in PostgreSQL 15+.|
+| Function                    | Privilege | Parameters | Description                                            |
+|-----------------------------|-----------|------------|--------------------------------------------------------|
+| `pgmoneta_ext_version()`    |   Default |    None    | Return the version number of `pgmoneta_ext` as a Datum.|
+| `pgmoneta_ext_switch_wal()` | SUPERUSER |    None    | A function for switching to a new WAL file.            |
+| `pgmoneta_ext_checkpoint()` | SUPERUSER <br>pg_checkpoint | None | A function which forces a checkpoint. <br>This function can only be executed by a `SUPERUSER` in PostgreSQL 13/14, but can also be executed by `pg_checkpoint` in PostgreSQL 15+. <br>You can use the SQL command `GRANT pg_checkpoint TO repl;` to assign the role in PostgreSQL 15+.|
+| `pgmoneta_ext_get_oid()`|   Default        | dbname  | Return the specific database OID by the database name.|
+| `pgmoneta_ext_get_oids()`    |   Default    | None   | Return all OIDs on the current server.|

--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -15,3 +15,11 @@ CREATE FUNCTION pgmoneta_ext_checkpoint(OUT success bool,
 RETURNS record 
 AS 'MODULE_PATHNAME' 
 LANGUAGE C STRICT;
+
+CREATE FUNCTION pgmoneta_ext_get_oid(dbname text) RETURNS text
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION pgmoneta_ext_get_oids() RETURNS SETOF RECORD
+AS 'MODULE_PATHNAME'
+LANGUAGE C;

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -35,8 +35,9 @@ extern "C" {
 #endif
 
 /* PostgreSQL */
-#include "postgres.h"
-#include "fmgr.h"
+#include <postgres.h>
+#include <fmgr.h>
+#include <nodes/pg_list.h>
 
 /* system */
 #include <stdbool.h>
@@ -44,6 +45,17 @@ extern "C" {
 #define PRIVILEDGE_DEFAULT            1 << 0  // 001
 #define PRIVILEDGE_PG_CHECKPOINT      1 << 1  // 010
 #define PRIVILEDGE_SUPERUSER          1 << 2  // 100
+
+#define MAX_DBNAME_LENGTH                     128
+
+/** @struct db_info
+ * Define a structure to hold both the OID and database name
+ */
+struct db_info
+{
+   Oid oid;                         /**< The OID of the database */
+   char dbname[MAX_DBNAME_LENGTH];  /**< The name of the database */
+} __attribute__ ((aligned (64)));
 
 /**
  * Check if the role has superuser privileges.
@@ -69,6 +81,22 @@ pgmoneta_ext_check_role(Oid roleid, const char* rolename);
  */
 int
 pgmoneta_ext_check_privilege(Oid roleid);
+
+/**
+ * Get the specific database OID by database name.
+ * @param dbname The name of the database.
+ * @return The OID of the database if found, otherwise InvalidOid.
+ */
+Oid
+pgmoneta_ext_get_oid_by_dbname(char* dbname);
+
+/**
+ * Get a list of all database OIDs and their names.
+ * @param dbname The name of the database.
+ * @return A list of db_info structs containing the OID and name of each database.
+ */
+List*
+pgmoneta_ext_get_all_oids(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This new function `pgmoneta_ext_get_oid` can get the specific database `OID` by the database name.

The next step is to get the queries we need using this OID and then send them to the core, similar to how `pg_dump` operates.

After this, we can use the extension to achieve the specific database backup.