### PR TITLE
[#22] Get LSN

### DIFF
--- a/doc/manual/user-02-functions.md
+++ b/doc/manual/user-02-functions.md
@@ -27,3 +27,4 @@ ALTER USER repl WITH NOSUPERUSER;
 | `pgmoneta_ext_get_oids()`    |   Default    | None   | Return all OIDs on the current server.|
 | `pgmoneta_ext_get_file()`|   SUPERUSER        | path/to/file  | Return the bytes of the specified file that is passed in.|
 | `pgmoneta_ext_get_files()`    |   SUPERUSER    | path/to/dir   | Return all file paths in the specified directory passed in.|
+| `pgmoneta_ext_get_lsn()`    |   Default    |  None   | Return the location of the last write of WAL.|

--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -28,6 +28,10 @@ CREATE FUNCTION pgmoneta_ext_get_file(file_path TEXT) RETURNS TEXT
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE OR REPLACE FUNCTION pgmoneta_ext_get_files(file_path TEXT) RETURNS text[]
+CREATE FUNCTION pgmoneta_ext_get_files(file_path TEXT) RETURNS text[]
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION pgmoneta_ext_get_lsn() RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;

--- a/src/pgmoneta_ext/lib.c
+++ b/src/pgmoneta_ext/lib.c
@@ -76,6 +76,7 @@ PG_FUNCTION_INFO_V1(pgmoneta_ext_get_oid);
 PG_FUNCTION_INFO_V1(pgmoneta_ext_get_oids);
 PG_FUNCTION_INFO_V1(pgmoneta_ext_get_file);
 PG_FUNCTION_INFO_V1(pgmoneta_ext_get_files);
+PG_FUNCTION_INFO_V1(pgmoneta_ext_get_lsn);
 
 Datum
 pgmoneta_ext_version(PG_FUNCTION_ARGS)
@@ -448,4 +449,17 @@ list_files(const char* name, ArrayBuildState* astate)
       }
    }
    closedir(dir);
+}
+
+Datum
+pgmoneta_ext_get_lsn(PG_FUNCTION_ARGS)
+{
+   XLogRecPtr lsn;
+   char lsn_str[64];
+
+   lsn = GetXLogWriteRecPtr();
+
+   snprintf(lsn_str, sizeof(lsn_str), "%X/%X", (uint32)(lsn >> 32), (uint32)lsn);
+
+   PG_RETURN_TEXT_P(cstring_to_text(lsn_str));
 }

--- a/test/lib/pgmoneta_ext_test.c
+++ b/test/lib/pgmoneta_ext_test.c
@@ -38,6 +38,7 @@
 #define PGMONETA_EXT_GET_FILES_REGEX      "^\\{((\\/[^,]+,?\\s*)*)\\}$"
 #define PGMONETA_EXT_GET_OID_REGEX        "^[1-9][0-9]*$"
 #define PGMONETA_EXT_GET_OIDS_REGEX       "^\\([1-9][0-9]*,[a-zA-Z0-9]+\\)$"
+#define PGMONETA_EXT_GET_LSN_REGEX       "^[A-Za-z0-9]+/[A-Za-z0-9]+$"
 
 #define PGMONETA_EXT_GET_FILE_PATH        "/pgsql/logfile"
 #define PGMONETA_EXT_GET_FILES_PATH        "/conf"
@@ -120,6 +121,15 @@ START_TEST(test_pgmoneta_ext_get_oids)
 }
 END_TEST
 
+START_TEST(test_pgmoneta_ext_get_lsn)
+{
+   char output[BUFFER_SIZE];
+   int result = execute_command("psql -h localhost -p 5432 -U repl -d postgres -t -c 'SELECT pgmoneta_ext_get_lsn();'", output, BUFFER_SIZE);
+   ck_assert_int_eq(result, 0);
+   ck_assert_msg(regex_match(output, PGMONETA_EXT_GET_LSN_REGEX) == 0, "Expected WAL switch result not found in output: %s", output);
+}
+END_TEST
+
 Suite*
 pgmoneta_ext_suite(void)
 {
@@ -137,6 +147,7 @@ pgmoneta_ext_suite(void)
    tcase_add_test(tc_core, test_pgmoneta_ext_get_files);
    tcase_add_test(tc_core, test_pgmoneta_ext_get_oid);
    tcase_add_test(tc_core, test_pgmoneta_ext_get_oids);
+   tcase_add_test(tc_core, test_pgmoneta_ext_get_lsn);
    suite_add_tcase(s, tc_core);
 
    return s;


### PR DESCRIPTION
I have added the new function `pgmoneta_ext_get_lsn()` and tested it on PostgreSQL 15.

```console
[postgres@fedora-linux-38 pgsql]$ psql -h localhost -p 5432 -U repl postgres 
Password for user repl: 
psql (15.1)
Type "help" for help.

postgres=# SELECT pgmoneta_ext_get_lsn();
 pgmoneta_ext_get_lsn 
----------------------
 0/8D072BF0
(1 row)

postgres=# SELECT pg_current_wal_lsn();
 pg_current_wal_lsn 
--------------------
 0/8D072BF0
(1 row)
```

The result is the same when compared to the PostgreSQL function, so I believe it's working correctly.

The next step is to create a new test suite to test this in the container environment.