### PR TITLE
[#22] Initial pgmoneta_ext_full_backup()

### DIFF
--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -24,10 +24,14 @@ CREATE FUNCTION pgmoneta_ext_get_oids() RETURNS SETOF RECORD
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION pgmoneta_ext_get_file(file_path TEXT) RETURNS TEXT
+CREATE FUNCTION pgmoneta_ext_get_file(file_path text) RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
-CREATE OR REPLACE FUNCTION pgmoneta_ext_get_files(file_path TEXT) RETURNS text[]
+CREATE FUNCTION pgmoneta_ext_get_files(file_path text) RETURNS text[]
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION pgmoneta_ext_full_backup() RETURNS text
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;


### PR DESCRIPTION
Initially, I use the `pgmoneta_ext_full_backup()` function to test and ensure that both `start_backup()` and `stop_backup()` functions work correctly.

Once these two functions are refined, the next step will be to create a new pull request to allow the core to send the manifest to the extension.