### PR TITLE
Added the set guc param function

### DIFF
--- a/sql/pgmoneta_ext--0.1.0.sql
+++ b/sql/pgmoneta_ext--0.1.0.sql
@@ -59,3 +59,18 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
 REVOKE ALL ON FUNCTION pgmoneta_ext_promote() FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION pgmoneta_ext_set_guc(
+   parameter text,
+   value text,
+   reload boolean DEFAULT true,
+   OUT guc_param text,
+   OUT old_value text,
+   OUT new_value text,
+   OUT restart_required boolean
+)
+RETURNS record
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+REVOKE ALL ON FUNCTION pgmoneta_ext_set_guc(text, text, boolean, OUT text, OUT text, OUT text, OUT boolean) FROM PUBLIC;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,16 @@ else (EXT_LIB_DIR)
   message(FATAL_ERROR "pg_config --libdir failed")
 endif (EXT_LIB_DIR)
 
+execute_process(COMMAND pg_config --bindir
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE EXT_BIN_DIR)
+
+if (EXT_BIN_DIR)
+  message(STATUS "Binary directory: ${EXT_BIN_DIR}")
+else (EXT_BIN_DIR)
+  message(FATAL_ERROR "pg_config --bindir failed")
+endif (EXT_BIN_DIR)
+
 #
 # OS
 #
@@ -64,13 +74,6 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${EXT_INCLUDE_DIR}
     ${EXT_INCLUDE_SERVER_DIR}
-  )
-
-  #
-  # Library directories
-  #
-  link_libraries(
-    ${EXT_LIB_DIR}/libpq.so
   )
 
 else()
@@ -89,13 +92,8 @@ else()
     ${EXT_INCLUDE_SERVER_DIR}
   )
 
-  #
-  # Library directories
-  #
-  link_libraries(
-    ${EXT_LIB_DIR}/libpq.so
-  )
 endif()
+link_directories(${EXT_LIB_DIR})
 
 #
 # Compile options
@@ -156,16 +154,20 @@ if (HAS_PIC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 endif()
 
-check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)
-if (HAS_RELRO)
-  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
-endif()
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 
-check_c_compiler_flag(-Wl,-z,now HAS_NOW)
-if (HAS_NOW)
-  set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
+  check_c_compiler_flag(-Wl,-z,relro HAS_RELRO)
+  if (HAS_RELRO)
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,relro")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
+  endif()
+
+  check_c_compiler_flag(-Wl,-z,now HAS_NOW)
+  if (HAS_NOW)
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
+  endif()
+
 endif()
 
 #
@@ -174,6 +176,15 @@ endif()
 add_library(pgmoneta_ext SHARED ${SOURCES})
 set_target_properties(pgmoneta_ext PROPERTIES LINKER_LANGUAGE C VERSION ${VERSION_STRING}
                                      SOVERSION ${VERSION_MAJOR} PREFIX "")
-target_link_libraries(pgmoneta_ext PUBLIC)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  # On macOS, PostgreSQL extensions are loaded as bundles
+  set_target_properties(pgmoneta_ext PROPERTIES
+    SUFFIX ".dylib"
+    LINK_FLAGS "-Wl,-undefined,dynamic_lookup"
+  )
+else()
+  target_link_libraries(pgmoneta_ext PRIVATE pq)
+endif()
 
 install(TARGETS pgmoneta_ext DESTINATION ${EXT_INSTALL_DIR}/)

--- a/src/pgmoneta_ext/utils.c
+++ b/src/pgmoneta_ext/utils.c
@@ -27,6 +27,8 @@
  *
  */
 
+#define _DARWIN_C_SOURCE
+
 /* pgmoneta_ext */
 #include <utils.h>
 


### PR DESCRIPTION
Relates [#607](https://github.com/pgmoneta/pgmoneta/issues/607) in pgmoneta

## Changes
- Fix macOS builds by adjusting CMake linking.
- Add pgmoneta_ext_set_guc(parameter text, value text, reload boolean default true):
    -  Uses `SET <param>` to set for current session and `ALTER <db> SET <param>` for future sessions
    - The function returns single row `guc_param | old_value | new_value | restart_required `

## Requirements
Like other functions, this would also require an explicit EXECUTE privilege to the pgmoneta role. 
Moreover the function will require that the calling user be one of the following:
1. SUPERUSER
2. Owner of the db